### PR TITLE
Add Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LoremSwiftum",
+    products: [
+        .library(
+            name: "LoremSwiftum",
+            targets: ["LoremSwiftum"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "LoremSwiftum",
+            dependencies: [],
+            path: "Sources"),
+    ]
+)


### PR DESCRIPTION
As the project is a simple file, I only added a `Package.swift` as small as possible

Maybe the xcodeproj isn't necessary as Xcode can open Package.swift files as "project" (try double clicking on it in the Finder)

Didn't added platforms in the `Package.swift`, so it default to all 4 platforms (see https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md)

Note a release might be published if you don't want user to track master branch (as SPM tries to enforce semver compliance)